### PR TITLE
Add comment to mark evervault as global

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+// The [Evervault Node.js SDK](https://docs.evervault.com/sdk/nodejs) is pre-initialized in all Cages as the globally-scoped `evervault` object.
+// This allows you to encrypt the result, and store it in your database.
+/*global evervault*/
+
 // event is the data you encrypted and passed into `evervault.run` from your server. 
 // The cage automatically decrypts the data and maintains its structure
 // so you can treat event exactly as you did when you passed it into `evervault.run`.


### PR DESCRIPTION
# Why
The Node.js SDK is globally available in Cages as `evervault`. Linters weren't aware of this during development.

# How
Add a `/*global evervault*/` comment at the start of the Cage source to prevent linters from complaining.