### PR TITLE
Improve `hello-cage` Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-# Why
-Add a short description about this PR.
-Add links to issues, tech plans etc.
-
-# How
-Describe how you've approached the problem

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const Evervault = require('@evervault/sdk');
 const evervault = new Evervault('<YOUR-API-KEY>');
 
 // Encrypt your data
-const encrypted = await evervault.encrypt({ name: 'Elon Musk' });
+const encrypted = await evervault.encrypt({ name: 'Claude Shannon' });
 ```
 
 ### Process your encrypted data in a cage

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This Cage is very simple. Here is the full code:
 
 ```javascript
 exports.handler = async (data) => {
-  if (data.name && data.name.length > 0) {
+  if (data.name && typeof data.name === "string") {
     console.debug(`A name of length ${data.name.length} has arrived into the Cage.`);
 
     return {

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This is a simple Evervault Cage example, to help get you up and running on the E
 
 ## Getting started with Evervault
 
-Evervault consists of two parts, encrypting your data at source, using either our Node SDK, or Browser and React SDKs and then sending that encrypted data to a cage to be processed securely.
+Evervault consists of two parts, encrypting your data at source, using either our Node SDK, or Browser and React SDKs and then sending that encrypted data to a Cage to be processed securely.
 
-This Cage takes a payload that should contain a `name` key. Running the cage is very simple.
+This Cage takes a payload that should contain a `name` key. Running the Cage is very simple.
 
 ## The steps
 1. Encrypt your data at source, using either the Node SDK or Browser and React SDKs.
-2. Process the encrypted data in a cage
+2. Process the encrypted data in a Cage
 
 ### Encrypting at source
 ```javascript
@@ -25,7 +25,7 @@ const evervault = new Evervault('<YOUR-API-KEY>');
 const encrypted = await evervault.encrypt({ name: 'Claude Shannon' });
 ```
 
-### Process your encrypted data in a cage
+### Process your encrypted data in a Cage
 You should encrypt this payload using either our Node SDK or Browser SDK, then run it in the Hello Cage:
 
 ```javascript
@@ -35,21 +35,21 @@ const result = await evervault.run('hello-cage', encrypted);
 
 ## Understanding the Cage
 This Cage is very simple. Here is the full code:
-```javascript
-exports.handler = async (event) => {
-  console.debug('This is the data that has arrived into the Cage.', event);
 
-  if (event.name && event.name.length > 0) {
+```javascript
+exports.handler = async (data) => {
+  if (data.name && data.name.length > 0) {
+    console.debug(`A name of length ${data.name.length} has arrived into the Cage.`);
+
     return {
-      message: `Hello, ${event.name}!`,
-      details: 'The cage is decrypting your name and returning it in plaintext',
-      encrypted: await evervault.encrypt(event.name),
+      message: `Hello from a Cage! It seems you have ${data.name.length} letters in your name`,
+      name: await evervault.encrypt(data.name),
     };
   } else {
+    console.debug('An empty name has arrived into the Cage.');
+
     return {
-      message: 'Hello, world!',
-      details:
-        'Please send an encrypted `name` parameter to show Cage decryption in action',
+      message: 'Hello from a Cage! Send an encrypted `name` parameter to show Cage decryption in action',
     };
   }
 };

--- a/cage.toml
+++ b/cage.toml
@@ -1,3 +1,3 @@
-# Sample input that can be used in the cage playground
+# Sample input that can be used in the Cage playground
 [cage.playground]
 name = "Claude Shannon"

--- a/cage.toml
+++ b/cage.toml
@@ -1,2 +1,3 @@
+# Sample input that can be used in the cage playground
 [cage.playground]
-name = "Elon Musk"
+name = "Claude Shannon"

--- a/index.js
+++ b/index.js
@@ -2,25 +2,25 @@
 // all Cages as the globally-scoped `evervault` object.This allows you to encrypt the result, 
 // and store it in your database.
 
-// `data` is the data you encrypted and passed into `evervault.run` from your server. The cage 
+// `data` is the data you encrypted and passed into `evervault.run` from your server. The Cage 
 // automatically decrypts the data and maintains its structure so you can treat event exactly as 
 // you did when you passed it into `evervault.run`.
 exports.handler = async (data) => {
-  // Check if the data sent into the cage has a key called `name` with a value that is longer than 0
+  // Check if the data sent into the Cage has a key called `name` with a value that is longer than 0
   if (data.name && data.name.length > 0) {
-    console.debug(`A name of length ${data.name.length} has arrived into the cage.`);
+    console.debug(`A name of length ${data.name.length} has arrived into the Cage.`);
 
     // Process the decrypted name value, and re-encrypt the original name using the globally available evervault package.
-    // Note all cages have the evervault SDK automatically injected into their global scope.
+    // Note all Cages have the evervault SDK automatically injected into their global scope.
     return {
-      message: `Hello from a cage! It seems you have ${data.name.length} letters in your name`,
+      message: `Hello from a Cage! It seems you have ${data.name.length} letters in your name`,
       name: await evervault.encrypt(data.name),
     };
   } else {
-    console.debug('An empty name has arrived into the cage.');
+    console.debug('An empty name has arrived into the Cage.');
 
     return {
-      message: 'Hello from a cage! Send an encrypted `name` parameter to show cage decryption in action',
+      message: 'Hello from a Cage! Send an encrypted `name` parameter to show Cage decryption in action',
     };
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@
 // automatically decrypts the data and maintains its structure so you can treat event exactly as 
 // you did when you passed it into `evervault.run`.
 exports.handler = async (data) => {
-  // Check if the data sent into the Cage has a key called `name` with a value that is longer than 0
-  if (data.name && data.name.length > 0) {
+  // Check if the data sent into the Cage included the `name` key
+  if (data.name && typeof data.name === "string") {
     console.debug(`A name of length ${data.name.length} has arrived into the Cage.`);
 
     // Process the decrypted name value, and re-encrypt the original name using the globally available evervault package.

--- a/index.js
+++ b/index.js
@@ -2,17 +2,6 @@
 // all Cages as the globally-scoped `evervault` object.This allows you to encrypt the result, 
 // and store it in your database.
 
-function createWelcomeMessage(name) {
-  const formattedName = name.split(' ').map(partialName => {
-    if (partialName.length > 1) {
-      return partialName[0] + '*'.repeat(partialName.length - 2) + partialName.slice(-1);
-    }
-    return partialName
-  }).join(' ');
-
-  return `Hello, ${formattedName}!`
-}
-
 // `data` is the data you encrypted and passed into `evervault.run` from your server. The cage 
 // automatically decrypts the data and maintains its structure so you can treat event exactly as 
 // you did when you passed it into `evervault.run`.
@@ -24,7 +13,7 @@ exports.handler = async (data) => {
     // Process the decrypted name value, and re-encrypt the original name using the globally available evervault package.
     // Note all cages have the evervault SDK automatically injected into their global scope.
     return {
-      message: createWelcomeMessage(data.name),
+      message: `Hello from a cage! It seems you have ${data.name.length} letters in your name`,
       name: await evervault.encrypt(data.name),
     };
   } else {

--- a/index.js
+++ b/index.js
@@ -1,28 +1,37 @@
-// The [Evervault Node.js SDK](https://docs.evervault.com/sdk/nodejs) is pre-initialized in all Cages as the globally-scoped `evervault` object.
-// This allows you to encrypt the result, and store it in your database.
-/*global evervault*/
+// The Evervault Node.js SDK (https://docs.evervault.com/sdk/nodejs) is pre-initialized in 
+// all Cages as the globally-scoped `evervault` object.This allows you to encrypt the result, 
+// and store it in your database.
 
-// event is the data you encrypted and passed into `evervault.run` from your server. 
-// The cage automatically decrypts the data and maintains its structure
-// so you can treat event exactly as you did when you passed it into `evervault.run`.
+function createWelcomeMessage(name) {
+  const formattedName = name.split(' ').map(partialName => {
+    if (partialName.length > 1) {
+      return partialName[0] + '*'.repeat(partialName.length - 2) + partialName.slice(-1);
+    }
+    return partialName
+  }).join(' ');
 
-exports.handler = async (event) => {
-  console.debug('This is the data that has arrived into the cage.', event);
+  return `Hello, ${formattedName}!`
+}
 
-  // Check if the event sent into the cage has a key called `name` and `name` has a value that is longer than 0
-  if (event.name && event.name.length > 0) {
-    // Return the decrypted name value, and then re-encrypt using the globally available evervault package.
+// `data` is the data you encrypted and passed into `evervault.run` from your server. The cage 
+// automatically decrypts the data and maintains its structure so you can treat event exactly as 
+// you did when you passed it into `evervault.run`.
+exports.handler = async (data) => {
+  // Check if the data sent into the cage has a key called `name` with a value that is longer than 0
+  if (data.name && data.name.length > 0) {
+    console.debug(`A name of length ${data.name.length} has arrived into the cage.`);
+
+    // Process the decrypted name value, and re-encrypt the original name using the globally available evervault package.
     // Note all cages have the evervault SDK automatically injected into their global scope.
     return {
-      message: `Hello, ${event.name}!`,
-      details: 'The cage is decrypting your name and returning it in plaintext',
-      encrypted: await evervault.encrypt(event.name),
+      message: createWelcomeMessage(data.name),
+      name: await evervault.encrypt(data.name),
     };
   } else {
+    console.debug('An empty name has arrived into the cage.');
+
     return {
-      message: 'Hello, world!',
-      details:
-        'Please send an encrypted `name` parameter to show cage decryption in action',
+      message: 'Hello from a cage! Send an encrypted `name` parameter to show cage decryption in action',
     };
   }
 };


### PR DESCRIPTION
# Why

This PR address a few small issues that existed with the template.

* The template was logging plaintext sensitive data in the Cage (the name which arrived encrypted), which is bad practice, so we shouldn't be doing it in our first introduction!
* The use of the `event` variable was confusing, as users might expect it to contain other things, which isn't really what we want
* The cage was missing a little bit of wow factor, mainly in processing the data in some way
* We had Elon Musk as the default name, not Claude Shannon (who's always relevant)
* The `.github` folder containing the Evervault PR template (which I am using now 😄) was being cloned into users cages, which isn't desirable.

# How

To fix these I've:

* Stopped logging plaintext data, and instead only log how many characters the name was 
* Changed `event` to `data`, which makes a lot more sense
* Sent the length of the name out in the message
* Changed the default name
* Deleted the `.github` folder

# Action Item!

Please give feedback (here or on slack) on the functionality of the cage!

At the moment we are creating a welcome message by taking the name length, but this isn't instantly recognisable as the name that was put in, which would be cool. Still doing something else might complicate the cage a bit, so I'd be happy to hear ideas